### PR TITLE
修复解析res://路径的getFileRealPath方法返回错误问题

### DIFF
--- a/src/org/zywx/wbpalmstar/plugin/uexfilemgr/EUExFileMgr.java
+++ b/src/org/zywx/wbpalmstar/plugin/uexfilemgr/EUExFileMgr.java
@@ -835,7 +835,9 @@ public class EUExFileMgr extends EUExBase {
 				BUtility.makeUrl(mBrwView.getCurrentUrl(), inPath),
 				mBrwView.getCurrentWidget().m_widgetPath,
 				mBrwView.getCurrentWidget().m_wgtType);
-		if(flag) {
+		if (flag && inPath != null
+				&& inPath.startsWith(BUtility.F_Widget_RES_path)) {
+			// 判断如果是解析res://协议并且解析出来的路径以widget/wgtRes/开头（即这是一个主应用没有开启增量更新的情况），就认为是assets路径
 			inPath = "file:///android_asset/" + inPath;
 			flag = false;
 		}

--- a/uexFileMgr/info.xml
+++ b/uexFileMgr/info.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <uexplugins>
     <plugin
-        uexName="uexFileMgr" version="3.0.2" build="2">
-		<info>2:修复res://协议下获取真实路径不正确的问题</info>
+        uexName="uexFileMgr" version="3.0.3" build="3">
+		<info>3:修复解析res://路径的getFileRealPath方法返回错误问题</info>
+		<build>2:修复res://协议下获取真实路径不正确的问题</build>
         <build>1:新增获取文件或文件夹的创建时间</build>
 		<build>0:文件管理功能插件</build>
     </plugin>


### PR DESCRIPTION
当时的3.0.2版本修改后的逻辑是有问题的，再次修复解析res://路径的getFileRealPath方法返回错误问题。
