### PR TITLE
修正部分成功失败状态回调的回调数据类型错误的问题。

### DIFF
--- a/src/org/zywx/wbpalmstar/plugin/uexfilemgr/EUExFileMgr.java
+++ b/src/org/zywx/wbpalmstar/plugin/uexfilemgr/EUExFileMgr.java
@@ -1738,8 +1738,8 @@ public class EUExFileMgr extends EUExBase {
     private void jsCallback(String inCallbackName, String inOpCode,
             int inDataType, int inData) {
         String js = SCRIPT_HEADER + "if(" + inCallbackName + "){"
-                + inCallbackName + "('" + inOpCode + "'," + inDataType + ",'"
-                + inData + "'" + SCRIPT_TAIL;
+                + inCallbackName + "('" + inOpCode + "'," + inDataType + ","
+                + inData + SCRIPT_TAIL;
         onCallback(js);
     }
     

--- a/uexFileMgr/info.xml
+++ b/uexFileMgr/info.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <uexplugins>
     <plugin
-        uexName="uexFileMgr" version="3.0.19" build="19">
-        <info>19:修正readFile接口的option参数可以为空</info>
+        uexName="uexFileMgr" version="3.0.20" build="20">
+        <info>20:修正部分成功失败的状态回调返回的回调数据类型错误的问题</info>
+        <build>19:修正readFile接口的option参数可以为空</build>
         <build>18:修复多选文件时会导致显示选择数量不正确的问题</build>
         <build>17.支持Base64读写</build>
         <build>16.修复拒绝服务漏洞的问题</build>


### PR DESCRIPTION
涉及到的接口比较多，包含isFileExistByPath，coypFile等大部分跟状态相关的接口。之前的版本是回调数字类型，在14版本错误更新成了字符串类型，导致部分应用的前端判断出现错误。现修正为原有的整型数字回调。
